### PR TITLE
Fix #9673 countries/show lists only the most recent status created

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :test do
   gem 'rspec-rails', '2.14.2'
   gem 'capybara', '2.3.0'
   gem 'poltergeist', '1.5.1'
+  gem 'shoulda-matchers', '~> 2.7.0', require: false
 end
 
 gem 'factory_girl_rails'

--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -1,11 +1,17 @@
 class CountriesController < ApplicationController
+  before_action :set_country, only: :show
+
   def index
     @countries = Country.all
   end
 
   def show
-    @country = Country.find(params[:id])
+    @statuses = @country.statuses.group_by { |s| s.value }.sort_by { |sg| -sg[0] }
+  end
 
-    @statuses = Status.most_recent.where( country: @country ).group_by { |s| s.value }.sort_by { |sg| -sg[0] }
+  private
+
+  def set_country
+    @country = Country.find(params[:id])
   end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,3 +1,4 @@
 class Country < ActiveRecord::Base
   has_many :proxies
+  has_many :statuses
 end

--- a/app/views/countries/show.html.erb
+++ b/app/views/countries/show.html.erb
@@ -2,7 +2,7 @@
 
 <h2><%#= t 'countries.changed_since' %></h2>
 
-<h2><%= t 'countries.top_urls' %></h2>
+<h2><%= t 'countries.recent' %></h2>
 
 <% @statuses.each { |status_group| %>
 <div class="list-group pages-status-<%= status_context_class status_group[1][0] %>">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
   countries:
     changed_since: 'Changed since yesterday'
     top_urls: 'Top URLs'
+    recent: 'Recent'
 
   pages:
     help: 'Check the availability of any URL by using the box above, or, try one of these:'

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -2,6 +2,10 @@
 
 FactoryGirl.define do
   factory :country do
+    name 'Country'
+    iso2 'iso2'
+    iso3 'iso3'
+
     factory :usa do
       name 'United States'
       iso2 'US'

--- a/spec/factories/statuses.rb
+++ b/spec/factories/statuses.rb
@@ -1,5 +1,9 @@
 FactoryGirl.define do
   factory :status do
+    value 0
+    delta 0
+    created_at '2014-11-19'
+
     factory :twitter_usa do
       #country usa
       #page twitter

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -1,19 +1,10 @@
 require 'spec_helper'
 
-describe( 'country model' ) {
-  context( 'valid attributes' ) {
-    let( :usa ) { Country.find_by_iso3 'USA' }
+describe Country do
+  it { should have_many(:statuses) }
+  it { should respond_to(:name, :iso3, :local_dns, :proxies) }
 
-    it {
-      usa.should be_valid
-
-      usa.should respond_to :name
-      usa.should respond_to :iso3
-      usa.should respond_to :local_dns
-    }
-
-    it {
-      usa.should respond_to :proxies
-    }
-  }
-}
+  it 'has a valid factory' do
+    expect(build(:country)).to be_valid
+  end
+end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,19 +1,6 @@
 require 'spec_helper'
 
-describe( 'status model' ) {
-  context( 'valid attributes' ) {
-    let( :status ) { Status.first }
-
-    it {
-      status.should be_valid
-    }
-
-    it { status.should respond_to :page }
-    it { status.should respond_to :country }
-    it { status.should respond_to :value }
-    it { status.should respond_to :delta}
-  }
-
+describe Status do
   describe( 'create_for_date' ) {
     let( :p ) { Page.find_by_title 'The White House' }
     let( :c ) { Country.find_by_name 'United States' }
@@ -46,4 +33,12 @@ describe( 'status model' ) {
       }
     }
   }
-}
+
+  it { should respond_to(:page, :country, :value, :delta) }
+  it { should belong_to(:page) }
+  it { should belong_to(:country) }
+
+  it 'has a valid factory' do
+    expect(build(:status)).to be_valid
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
 require 'capybara/poltergeist'
+require 'shoulda/matchers'
 
 def snap
   save_screenshot("tmp/screenshots/#{(Time.now.to_f * 1000).floor}.png")

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+    config.include FactoryGirl::Syntax::Methods
+end

--- a/spec/views/countries/show.html.erb_spec.rb
+++ b/spec/views/countries/show.html.erb_spec.rb
@@ -28,8 +28,8 @@ describe ( 'countries/show' ) {
       it { pending "should have_css 'h2', text: 'Changed since yesterday'" }
     }
 
-    describe ( 'top urls' ) {
-      it { should have_css 'h2', text: 'Top URLs' }
+    describe ( 'recent' ) {
+      it { should have_css 'h2', text: 'Recent' }
 
       it {
         # Iran has a 0, 2, & 3


### PR DESCRIPTION
- Change 'Top URLs' heading to 'Recent' on countries/show
- Associate countries with statuses
- Update CountriesController to retrieve all statuses for a country
- Install shoulda-matchers gem
- Load shoulda-matchers in spec_helper
- Configure RSpec to use factory_girl
- Update Country unit tests and factory
- Update Status unit tests and factory
