### PR TITLE
Resolve #9436 cache favicons

### DIFF
--- a/app/assets/images/favicons/.gitignore
+++ b/app/assets/images/favicons/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore

--- a/app/views/pages/_icon_title.html.erb
+++ b/app/views/pages/_icon_title.html.erb
@@ -1,1 +1,1 @@
-<%= image_tag "http://www.google.com/s2/favicons?domain=#{URI.parse(icon_title.url).host}", alt: '' %> <span><%= title_or_url icon_title %></span>
+<%= image_tag "favicons/#{icon_title.id}.ico", alt: '' %> <span><%= title_or_url icon_title %></span>

--- a/app/views/pages/_page.html.erb
+++ b/app/views/pages/_page.html.erb
@@ -1,5 +1,5 @@
 <div class="page media">
-  <%= link_to image_tag( "http://www.google.com/s2/favicons?domain=#{URI.parse(page.url).host}", alt: '', class: 'media-object' ), page_path( page ), class: 'pull-left' %>
+  <%= link_to image_tag("favicons/#{page.id}.ico", alt: 'favicon', class: 'media-object' ), page_path( page ), class: 'pull-left' %>
   <div class="media-body">
     <h4 class="media-heading"><%= page.title %></h4>
     <p><%= page.url %></p>

--- a/app/views/statuses/_status.html.erb
+++ b/app/views/statuses/_status.html.erb
@@ -1,1 +1,1 @@
-<%= image_tag "http://www.google.com/s2/favicons?domain=#{URI.parse(status.page.url).host}", alt: '' %> <span><%= raw t( "statuses.title_in_country.#{status.value}", title: title_or_url( status.page ), country: status.country.name ) %></span>
+<%= image_tag "favicons/#{status.page.id}.ico", alt: 'Favicon' %> <span><%= raw t( "statuses.title_in_country.#{status.value}", title: title_or_url( status.page ), country: status.country.name ) %></span>

--- a/app/workers/favicon_cacher_worker.rb
+++ b/app/workers/favicon_cacher_worker.rb
@@ -1,0 +1,9 @@
+class FaviconCacherWorker
+  include Sidekiq::Worker
+
+  def perform(page_id)
+    page = Page.find(page_id)
+
+    Favicon::Cacher.cache(page.id, page.url)
+  end
+end

--- a/config/initializers/favicon.rb
+++ b/config/initializers/favicon.rb
@@ -1,0 +1,4 @@
+require 'favicon'
+
+::FAVICON_PATH = 'app/assets/images/favicons/'
+::FAVICON_EXPIRATION_DAYS = 7

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,5 +4,5 @@
 ---
 :verbose: false
 #:pidfile: ./tmp/pids/sidekiq.pid
-:concurrency: 100
+:concurrency: 25
 #:timeout: 30

--- a/lib/favicon.rb
+++ b/lib/favicon.rb
@@ -1,0 +1,4 @@
+module Favicon
+  require 'favicon/cacher'
+  require 'favicon/retriever'
+end

--- a/lib/favicon/cacher.rb
+++ b/lib/favicon/cacher.rb
@@ -1,0 +1,19 @@
+module Favicon::Cacher
+  def self.cache(file_name, url)
+    file_path = Rails.root.join(FAVICON_PATH, "#{file_name}.ico")
+
+    if expired?(file_path)
+      Favicon::Retriever.retrieve(file_path, url)
+    end
+  end
+
+  private
+
+  def self.expired?(file_path)
+    return true unless File.exist?(file_path)
+
+    file_age_in_days = (Time.now - File.stat(file_path).mtime).to_i / 86400.0
+
+    file_age_in_days > FAVICON_EXPIRATION_DAYS
+  end
+end

--- a/lib/favicon/retriever.rb
+++ b/lib/favicon/retriever.rb
@@ -1,0 +1,11 @@
+module Favicon::Retriever
+  def self.retrieve(file_path, url)
+    file = File.new(file_path, 'w')
+
+    file.binmode
+    file << open(
+      "http://www.google.com/s2/favicons?domain=#{URI.parse(url).host}"
+    ).read
+    file.close
+  end
+end

--- a/lib/tasks/netclerk_favicon.rake
+++ b/lib/tasks/netclerk_favicon.rake
@@ -1,0 +1,12 @@
+namespace :netclerk do
+  namespace :favicon do
+    desc 'Update expired/missing favicons for all pages'
+    task cache_all: :environment do
+      cache_favicons(Page.all)
+    end
+  end
+end
+
+def cache_favicons(pages)
+  pages.find_each { |page| FaviconCacherWorker.perform_async(page.id) }
+end

--- a/lib/tasks/netclerk_seed.rake
+++ b/lib/tasks/netclerk_seed.rake
@@ -124,7 +124,10 @@ def seed_oni
         url = line['url']
         if Page.find_by( url: url ).nil?
           page = Page.new( url: url)
-          page.save
+
+          if page.save
+            FaviconCacherWorker.perform_async(page.id)
+          end
         end
       end
     end

--- a/spec/lib/favicon/cacher_spec.rb
+++ b/spec/lib/favicon/cacher_spec.rb
@@ -1,0 +1,27 @@
+require 'favicon/retriever'
+
+module Favicon
+  describe Cacher do
+    describe '.favicon' do
+      let(:file_name) { '1' }
+      let(:file_path) { Rails.root.join(FAVICON_PATH, "#{file_name}.ico") }
+      let(:url) { 'http://www.example.com' }
+
+      it 'calls Favicon::Retriever if the cached favicon has expired' do
+        allow(Cacher).to receive(:expired?) { true }
+        stub_const('Favicon::Retriever', double)
+        expect(Favicon::Retriever).to receive(:retrieve).with(file_path, url)
+
+        Favicon::Cacher.cache(file_name, url)
+      end
+
+      it 'does not call Favicon::Retriever if the cached favicon has not expired' do
+        allow(Cacher).to receive(:expired?) { false }
+        stub_const('Favicon::Retriever', double)
+        expect(Favicon::Retriever).not_to receive(:retrieve)
+
+        Favicon::Cacher.cache(file_name, url)
+      end
+    end
+  end
+end

--- a/spec/lib/favicon/retriever_spec.rb
+++ b/spec/lib/favicon/retriever_spec.rb
@@ -1,0 +1,22 @@
+require 'favicon/retriever'
+
+module Favicon
+  describe Retriever do
+    describe '.retrieve' do
+      let(:file_path) { Rails.root.join(FAVICON_PATH, '1.ico') }
+      let(:url) { 'http://www.example.com' }
+      let(:file) { double }
+
+      it "creates a local copy of a site's favicon" do
+        allow(Retriever).to receive(:open) { double(read: double) }
+
+        expect(File).to receive(:new).with(file_path, 'w') { file }
+        expect(file).to receive(:binmode)
+        expect(file).to receive('<<')
+        expect(file).to receive(:close)
+
+        Retriever.retrieve(file_path, url)
+      end
+    end
+  end
+end

--- a/spec/lib/favicon_spec.rb
+++ b/spec/lib/favicon_spec.rb
@@ -1,0 +1,4 @@
+module Favicon
+  describe Favicon do
+  end
+end

--- a/spec/views/pages/_icon_title.html.erb_spec.rb
+++ b/spec/views/pages/_icon_title.html.erb_spec.rb
@@ -15,7 +15,7 @@ describe ( 'pages/icon_title' ) {
     }
 
     it {
-      should have_css 'img[src="http://www.google.com/s2/favicons?domain=twitter.com"]'
+      should have_xpath "//img[contains(@src, \"#{twitter.id}.ico\")]"
     }
 
     it {

--- a/spec/views/pages/_page.html.erb_spec.rb
+++ b/spec/views/pages/_page.html.erb_spec.rb
@@ -21,9 +21,7 @@ describe ( 'pages/page' ) {
 
   it { should have_css 'img.media-object' }
 
-  it {
-    should have_css 'img[src="http://www.google.com/s2/favicons?domain=twitter.com"]'
-  }
+  it { should have_xpath "//img[contains(@src, \"#{page.id}.ico\")]" }
 
   it { should have_css '.media-body' }
 

--- a/spec/views/statuses/_status.html.erb_spec.rb
+++ b/spec/views/statuses/_status.html.erb_spec.rb
@@ -13,9 +13,7 @@ describe ( 'statuses/status' ) {
       render status
     }
 
-    it {
-      should have_css 'img[src="http://www.google.com/s2/favicons?domain=www.whitehouse.gov"]'
-    }
+    it { should have_xpath "//img[contains(@src, \"#{page.id}.ico\")]" }
 
     it {
       should have_css 'span', text: 'The White House is very different in'

--- a/spec/workers/favicon_cacher_worker_spec.rb
+++ b/spec/workers/favicon_cacher_worker_spec.rb
@@ -1,0 +1,12 @@
+describe FaviconCacherWorker do
+  describe '.perform' do
+    let(:page) { double(id: 1, url: 'http://www.example.com') }
+
+    it 'calls the method for caching a favicon' do
+      allow(Page).to receive(:find) { page }
+      expect(Favicon::Cacher).to receive(:cache).with(page.id, page.url)
+
+      FaviconCacherWorker.new.perform(page.id)
+    end
+  end
+end


### PR DESCRIPTION
- Add favicon initializer
- Add Favicon::Cacher module
- Add Favicon::Retriever module
- Remove Page#icon method
- Remove PagesController#cached_icon
- Fix Page view test
- Add FaviconCacherWorker
- Update seed_oni Rake task to cache favicons when creating new Pages
- Reduce Sidekiq concurrency
- Add images/favicons assets directory to repo
- Add netclerk:favicons:cache Rake task
