### PR TITLE
11444 tie status to requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,9 @@ gem 'sqlite3'
 group :test do
   gem 'rspec-rails', '~> 2.99.0'
   gem 'capybara', '~> 2.4.0'
-  gem 'phantomjs', '~> 1.9.0'
   gem 'poltergeist', '~> 1.6.0'
   gem 'shoulda-matchers', '~> 2.7.0', require: false
+  gem 'webmock', '~> 1.21.0', require: false
 end
 
 gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     arel (5.0.1.20140414130214)
     autoprefixer-rails (4.0.2.1)
       execjs
@@ -52,6 +53,8 @@ GEM
       execjs
     coffee-script-source (1.8.0)
     connection_pool (2.1.0)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     d3_rails (3.5.2)
       railties (>= 3.1.0)
     diff-lcs (1.2.5)
@@ -87,7 +90,6 @@ GEM
       mini_portile (~> 0.6.0)
     pg (0.17.1)
     pg (0.17.1-x86-mingw32)
-    phantomjs (1.9.8.0)
     poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -136,6 +138,7 @@ GEM
       rspec-expectations (~> 2.99.0)
       rspec-mocks (~> 2.99.0)
     rubyzip (1.1.7)
+    safe_yaml (1.0.4)
     sass (3.2.19)
     sass-rails (4.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -183,6 +186,9 @@ GEM
     uglifier (2.6.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    webmock (1.21.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     websocket-driver (0.5.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -205,7 +211,6 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   pg
-  phantomjs (~> 1.9.0)
   poltergeist (~> 1.6.0)
   rails (= 4.1.1)
   rspec-rails (~> 2.99.0)
@@ -218,3 +223,4 @@ DEPENDENCIES
   sqlite3
   tzinfo-data
   uglifier (>= 1.3.0)
+  webmock (~> 1.21.0)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@ NetClerk
 ========
 
 Automatic daily testing of access to URLs from other countries via public proxy servers
+
+Testing
+-------
+Before running tests, run the command:
+`bundle exec rake netclerk:seed:test RAILS_ENV=test`

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -49,4 +49,12 @@ class Status < ActiveRecord::Base
 
     status
   end
+
+  def requests
+    Request.where(id: request_ids)
+  end
+
+  def requests=(array)
+    self.request_ids = array.collect(&:id)
+  end
 end

--- a/db/migrate/20150417001807_add_request_ids_to_statuses.rb
+++ b/db/migrate/20150417001807_add_request_ids_to_statuses.rb
@@ -1,0 +1,5 @@
+class AddRequestIdsToStatuses < ActiveRecord::Migration
+  def change
+    add_column :statuses, :request_ids, :text, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150110201353) do
+ActiveRecord::Schema.define(version: 20150417001807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 20150110201353) do
     t.integer  "delta"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "request_ids", default: [], array: true
   end
 
   add_index "statuses", ["country_id"], name: "index_statuses_on_country_id", using: :btree

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -13,7 +13,7 @@ describe Country do
     it { Country.should respond_to( :having_requests_on ) }
 
     it 'should scope to request date' do
-      Country.having_requests_on( '2014-07-11' ).count.should eq( 1 )
+      Country.having_requests_on( '2014-07-11' ).count.should eq( 2 )
     end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -43,12 +43,23 @@ describe Page do
     let( :p ) { Page.find_by_title 'The White House' }
 
     before {
+      stub_request(
+        :get, "http://www.whitehouse.gov/"
+      ).with(
+        :headers => {
+          'Accept'=>'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Accept-Language'=>'en-US,en;q=0.8',
+          'Connection'=>'close',
+          'User-Agent'=>'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36'
+        }
+      ).to_return(:status => 200, :body => "The Home Page for the White House of the United States.", :headers => {})
       Rails.cache.delete p.url
     }
 
     it {
       p.baseline_content.should_not be_nil
-      Rails.cache.exist?( p.url ).should be_true
+      expect(Rails.cache.exist?( p.url )).to be(true)
     }
   }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'rspec/rails'
 require 'rspec/autorun'
 require 'capybara/poltergeist'
 require 'shoulda/matchers'
+require 'webmock/rspec'
 
 def snap
   save_screenshot("tmp/screenshots/#{(Time.now.to_f * 1000).floor}.png")
@@ -51,4 +52,6 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = "random"
+
+  WebMock.disable_net_connect!(allow_localhost: true)
 end


### PR DESCRIPTION
Went with a postgresql array column rather than a full has-and-belongs-to-many relation. Didn't seem like request.statuses would be as useful as status.requests so didn't include the extra infrastructure to make that happen.