### PR TITLE
Resolve #11355 Ignore pages after 3 days of local failure

### DIFF
--- a/db/migrate/20151102043734_add_failed_at_and_fail_count_to_page.rb
+++ b/db/migrate/20151102043734_add_failed_at_and_fail_count_to_page.rb
@@ -1,0 +1,6 @@
+class AddFailedAtAndFailCountToPage < ActiveRecord::Migration
+  def change
+    add_column :pages, :failed_at, :date
+    add_column :pages, :fail_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150421234131) do
+ActiveRecord::Schema.define(version: 20151102043734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,8 @@ ActiveRecord::Schema.define(version: 20150421234131) do
     t.integer  "category_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.date     "failed_at"
+    t.integer  "fail_count",  default: 0, null: false
   end
 
   add_index "pages", ["category_id"], name: "index_pages_on_category_id", using: :btree

--- a/lib/tasks/netclerk.rake
+++ b/lib/tasks/netclerk.rake
@@ -128,10 +128,15 @@ def netclerk_scan( input_dir )
 
     #puts "  #{country.name}: #{ActionController::Base.helpers.pluralize(proxies.count, 'proxy')}"
 
-    Page.all.each do |page|
-      unless page.failed_locally?
-        proxies.each { |proxy| ProxyRequest.perform_async(country.id, page.id, proxy) }
+    Page.requestable.find_each do |page|
+      if page.failed_locally?
+        page.mark_as_failed_today!
+        next
+      else
+        page.reset_failures!
       end
+
+      proxies.each { |proxy| ProxyRequest.perform_async(country.id, page.id, proxy) }
     end
   end
 end


### PR DESCRIPTION
  * Add requestable scope to Page model
  * Add failed_at and failed_count attributes to Pages
  * Add Page methods for working with failure attributes
  * Update netclerk_scan Rake task to update Page failures