### PR TITLE
Resolve #12152 Populate page titles during netclerk_scan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin]
 # sidekiq for all the requests
 gem 'sidekiq'
 gem 'sinatra', '>= 1.3.0', :require => nil
+
+# Nokogiri for parsing HTML
+gem 'nokogiri', '~> 1.6.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,7 @@ DEPENDENCIES
   factory_girl_rails
   jbuilder (~> 2.0)
   jquery-rails
+  nokogiri (~> 1.6.6)
   oj
   pg
   poltergeist (~> 1.6.0)

--- a/lib/tasks/netclerk.rake
+++ b/lib/tasks/netclerk.rake
@@ -132,8 +132,13 @@ def netclerk_scan( input_dir )
       if page.failed_locally?
         page.mark_as_failed_today!
         next
-      else
-        page.reset_failures!
+      end
+
+      page.reset_failures!
+
+      if page.title.blank?
+        title = Nokogiri::HTML(page.baseline_content).css('title').text.truncate(255)
+        page.update!(title: title) if title.present?
       end
 
       proxies.each { |proxy| ProxyRequest.perform_async(country.id, page.id, proxy) }


### PR DESCRIPTION
  * Install Nokogiri gem
  * Update netclerk_scan task to replace blank page titles with title text extracted from base_content HTML