### PR TITLE
Fix RSpec 3 deprecation warning

### DIFF
--- a/spec/requests/laapi/requests_spec.rb
+++ b/spec/requests/laapi/requests_spec.rb
@@ -27,7 +27,7 @@ describe ( 'requests requests' ) {
 
         it {
           #puts page.source
-          pending 'page.status_code.should eq( 200 )'
+          skip 'page.status_code.should eq( 200 )'
         }
       }
     }


### PR DESCRIPTION
Minor change to eliminate RSpec warnings when running the full test suite.